### PR TITLE
Node 10 compatibility fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,10 +50,16 @@ module.exports = (args, flags) => {
         fs.mkdirSync(flags.outputDir);
       }
 
-      await fs.writeFile(`${flags.outputDir}/hubble-data.json`, prettyJSON(mapping));
+      const fsErrorHandler = (err) => {
+        if (err) {
+          throw new Error(err);
+        }
+      };
+
+      await fs.writeFile(`${flags.outputDir}/hubble-data.json`, prettyJSON(mapping), fsErrorHandler);
 
       if (flags.dump) {
-        await fs.writeFile(`${flags.outputDir}/logdump.json`, prettyJSON(response));
+        await fs.writeFile(`${flags.outputDir}/logdump.json`, prettyJSON(response), fsErrorHandler);
       }
 
       return response;

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ module.exports = (args, flags) => {
 
       const fsErrorHandler = (err) => {
         if (err) {
+          console.error('Error trying to write to file:', err); // eslint-disable-line no-console
           throw new Error(err);
         }
       };


### PR DESCRIPTION
Added required error handler for fs.writeFile. This caused a deprecation warning in node 8, and crashed the app in node 10.

