### PR TITLE
Normalize the asset output

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 In The Pocket (ITP Agency NV)
+Copyright (c) 2019 - current In The Pocket (ITP Agency NV)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For more information on our Style Dictionary output, check [the wiki][wiki style
 Assets can be exported using the `sketchtool.sh` script. This process exports all layers marked as exportable or that have been sliced.
 
 ```shell
-# This will export assets as SVG (for web) and PNG (1x, 2x, 3x for native)
+# This will export normalized (lowercase, underscore) assets as SVG (for web) and PNG (1x, 2x, 3x for native)
 $ ./sketchtool.sh "/Users/hubble/Desktop/MyDesign.sketch"
 
 # You can optionally specify an asset output dir. Otherwise current working directory will be used:

--- a/sketchtool.sh
+++ b/sketchtool.sh
@@ -15,7 +15,11 @@ function check_file_input() {
     exit 1
   fi
 
-  if [ -z "$2" ]; then OUTPUT_DIR="$PWD/assets/images"; else OUTPUT_DIR=$2; fi
+  if [ -z "$2" ]; then
+    OUTPUT_DIR="$PWD/assets/images"
+  else
+    OUTPUT_DIR=$2
+  fi
 }
 
 function export_assets() {
@@ -40,8 +44,17 @@ function export_assets() {
   fi
 }
 
+function transform_assets() {
+  find "$OUTPUT_DIR" -name '*.png' | while read -r line; do
+    mv "$line" "$(echo "$line" | tr "[:upper:]" "[:lower:]" | tr ' ' '_')"
+  done
+  find "$OUTPUT_DIR" -name '*.svg' | while read -r line; do
+    mv "$line" "$(echo "$line" | tr "[:upper:]" "[:lower:]" | tr ' ' '_')"
+  done
+}
+
 function main() {
   check_file_input "$@"
-  export_assets "$@"
+  export_assets "$@" && transform_assets
 }
 main "$@"


### PR DESCRIPTION
This makes working with the asset filepath a bit more friendly for developers and cross-platform projects. It removes the uppercase letters and replaces spaces with underscores

![Screenshot 2019-05-28 at 17 09 59](https://user-images.githubusercontent.com/6213695/58489422-8dae3980-816b-11e9-99a1-f60d63e61f74.png)
![Screenshot 2019-05-28 at 17 09 10](https://user-images.githubusercontent.com/6213695/58489431-90109380-816b-11e9-9d38-23930b26953a.png)
