### PR TITLE
Export extra scales 1.5x and 4x for Android

### DIFF
--- a/sketchtool.sh
+++ b/sketchtool.sh
@@ -26,10 +26,10 @@ function export_assets() {
   fi
 
   if [ -f /Applications/Sketch.app/Contents/Resources/sketchtool/bin/sketchtool ]; then
-    log "Exporting slices as svg & png(1x,2x,3x) to directory $2"
+    log "Exporting slices as svg & png(1x,1.5x,2x,3x,4x) to directory $2"
 
     /Applications/Sketch.app/Contents/Resources/sketchtool/bin/sketchtool export slices "$1" --output="$OUTPUT_DIR" \
-      --format="png" --scales="1, 2, 3"
+      --format="png" --scales="1, 1.5, 2, 3, 4"
 
     /Applications/Sketch.app/Contents/Resources/sketchtool/bin/sketchtool export slices "$1" --output="$OUTPUT_DIR" \
       --format="svg"


### PR DESCRIPTION
```console
$ ls -l assets/images/primitives/flags/
total 832
-rw-r--r--  1 thibault  staff     426 May 28 17:38 Algeria.png # 1x
-rw-r--r--  1 thibault  staff     702 May 28 17:38 Algeria@1x.png # 1.5x
-rw-r--r--  1 thibault  staff     991 May 28 17:38 Algeria@2x.png # 2x
-rw-r--r--  1 thibault  staff    1738 May 28 17:38 Algeria@3x.png # 3x
-rw-r--r--  1 thibault  staff    2664 May 28 17:38 Algeria@4x.png # 4x
```

> “drawable-mdpi” is where you put assets for the @1x resolution,
> “drawable-hdpi” corresponds to @1.5x resolution
> “drawable-xhdpi” is for @2x resolution
> “drawable-xxhdpi” is for @3x resolution
> “drawable-xxxhdpi” is for @4x resolution

We can later map these via postprocessing to their correct folder