### PR TITLE
Correctly map the 1.5x scale

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "start:artboards": "npm start -- --dump --useColorArtboards --useGradientArtboards",
     "start:styledictionary": "npm start -- --dump --useColorArtboards --useGradientArtboards --useStyleDictionaryOutput",
     "clean": "rm hubble-data.json && rm -rf sketchtool-export node_modules && npm install",
-    "export": "./sketchtool.sh",
+    "export": "./sketchtool.sh ./__mocks__/sample_sketchfile.sketch",
     "lint": "itp-react-scripts lint",
     "lint:fix": "npm run lint -- --fix",
     "lint:shell": "which shellcheck > /dev/null && shellcheck *.sh",

--- a/sketchtool.sh
+++ b/sketchtool.sh
@@ -44,10 +44,13 @@ function export_assets() {
   fi
 }
 
+# Transform asset filenames to all lowercase, replace spaces with underscores.
+# Sketchtool incorrectly maps 1.5x to 1x, replace that as well.
 function transform_assets() {
   find "$OUTPUT_DIR" -name '*.png' | while read -r line; do
-    mv "$line" "$(echo "$line" | tr "[:upper:]" "[:lower:]" | tr ' ' '_')"
+    mv "$line" "$(echo "$line" | tr "[:upper:]" "[:lower:]" | tr ' ' '_' | sed s/@1x/@1.5x/)"
   done
+
   find "$OUTPUT_DIR" -name '*.svg' | while read -r line; do
     mv "$line" "$(echo "$line" | tr "[:upper:]" "[:lower:]" | tr ' ' '_')"
   done


### PR DESCRIPTION
The binary `sketchtool` has a bug where it maps the 1.5x scale to @1x in the filename. This replaces it